### PR TITLE
Add IP remembering, NTP validation, and UI improvements

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -11,8 +11,8 @@ permissions:
 env:
   PYTHON_VERSION: '3.11'
   CI_DEBUG: true
-  POETRY_VERSION: '2.1.3'
-  PYINSTALLER_VERSION: '6.13'
+  POETRY_VERSION: '2.1.4'
+  PYINSTALLER_VERSION: '6.15'
 
 jobs:
   update-dependencies:

--- a/locales.py
+++ b/locales.py
@@ -66,6 +66,10 @@ arising from the use of this program.
                 en="3. Your TV, Nvidia Shield, and PC must be connected to the same network.",
                 ru="3. Ваш ТВ, Nvidia Shield и ПК должны быть подключены к одной сети"
             ),
+            "reboot_device": Translation(
+                en="4. Reboot your TV or Nvidia Shield before using this program.",
+                ru="4. Сделайте перезагрузку вашего ТВ или Nvidia Shield перед использованием программы."
+            ),
             "press_enter_to_continue": Translation(
                 en="\nPress Enter to continue...",
                 ru="\nНажмите Enter, чтобы продолжить..."
@@ -79,6 +83,15 @@ arising from the use of this program.
             "logger_warning_2": Translation(
                 en="Failed to save servers: {error}",
                 ru="Не удалось сохранить серверы: {error}"
+            ),
+            # settings load/save errors
+            "settings_load_error": Translation(
+                en="Failed to load settings: {error}",
+                ru="Не удалось загрузить настройки: {error}"
+            ),
+            "settings_save_error": Translation(
+                en="Failed to save settings: {error}",
+                ru="Не удалось сохранить настройки: {error}"
             ),
             # copy_server_to_clipboard
             "copy_to_clipboard": Translation(
@@ -760,9 +773,17 @@ arising from the use of this program.
                 en="Enter the IP address of your device (TV, Nvidia Shield) (find it in Settings > Network and Internet): ",
                 ru="Введите IP-адрес вашего устройства (ТВ, Nvidia Shield) (найдите в Настройки > Сеть и интернет): "
             ),
+            "enter_device_ip_with_saved": Translation(
+                en="Enter the IP address of your device (press Enter to use saved: {saved_ip}): ",
+                ru="Введите IP-адрес устройства (нажмите Enter для использования сохранённого: {saved_ip}): "
+            ),
             "invalid_ip_format": Translation(
                 en="Invalid IP address format. Use the format: xxx.xxx.xxx.xxx",
                 ru="Неверный формат IP-адреса. Используйте формат: xxx.xxx.xxx.xxx"
+            ),
+            "invalid_ntp_server_format": Translation(
+                en="Invalid NTP server format. Use a valid domain name (e.g., time.google.com) or IP address.",
+                ru="Неверный формат NTP-сервера. Используйте корректное доменное имя (например, time.google.com) или IP-адрес."
             ),
             "enter_country_code": Translation(
                 en="Enter your country code (e.g. us for USA, uk for United Kingdom, see country codes menu, q to exit): ",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,10 @@ version = "1.0.0"
 description = "Time fixer for Android TV"
 authors = ["Orientalium"]
 readme = "README.md"
-packages = [{include = "src/android_time_fixer.py"}]
+packages = [
+    {include = "src/android_time_fixer.py"},
+    {include = "locales.py"}
+]
 classifiers = [
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: Microsoft :: Windows",
@@ -23,8 +26,8 @@ cryptography = "^45.0.7"
 rsa = "^4.9.1"
 ntplib = "^0.4.0"
 
-# Windows-специфичные зависимости
-psutil = { version = "^7.0.0", markers = "sys_platform == 'win32' or sys_platform == 'darwin'" }
+# Общая зависимость для всех платформ
+psutil = "^7.0.0"
 wmi = { version = "^1.5.1", markers = "sys_platform == 'win32'" }
 
 # macOS-специфичные зависимости

--- a/scripts/hooks/linux_hook.py
+++ b/scripts/hooks/linux_hook.py
@@ -5,6 +5,12 @@ import stat
 from pathlib import Path
 from typing import List
 
+# Global ADB path for import by android_time_fixer.py
+ADB_PATH = os.path.join(
+    getattr(sys, '_MEIPASS', os.path.dirname(os.path.abspath(__file__))),
+    'resources', 'adb'
+)
+
 def setup_linux_environment() -> None:
     logger = _setup_logger()
     try:

--- a/scripts/hooks/macos_hook.py
+++ b/scripts/hooks/macos_hook.py
@@ -6,6 +6,12 @@ import subprocess
 from pathlib import Path
 from typing import Optional
 
+# Global ADB path for import by android_time_fixer.py
+ADB_PATH = os.path.join(
+    getattr(sys, '_MEIPASS', os.path.dirname(os.path.abspath(__file__))),
+    'resources', 'adb'
+)
+
 def setup_macos_environment() -> None:
     logger = _setup_logger()
     try:

--- a/scripts/hooks/win_hook.py
+++ b/scripts/hooks/win_hook.py
@@ -5,6 +5,12 @@ import ctypes
 from pathlib import Path
 from typing import Set
 
+# Global ADB path for import by android_time_fixer.py
+ADB_PATH = os.path.join(
+    getattr(sys, '_MEIPASS', os.path.dirname(os.path.abspath(__file__))),
+    'resources', 'adb.exe'
+)
+
 def setup_windows_environment() -> None:
     logger = setup_logger()
     try:


### PR DESCRIPTION
Features:
- Add automatic IP address remembering (saved in settings.json)
- Add NTP server domain name validation before applying changes
- Add 4th setup instruction about device reboot requirement
- Show saved IP and allow quick selection with Enter key

Localization:
- Add translations for new features (settings errors, IP prompt, NTP validation)
- Add reboot_device instruction for both languages

Config fixes:
- Fix pyproject.toml to include locales.py in packages
- Fix psutil dependency to work on all platforms (not just win32/darwin)
- Sync Poetry and PyInstaller versions across workflow files
- Add ADB_PATH export to all platform hooks (linux, macos, windows)