### PR TITLE
Add port availability check before ADB connection attempt

### DIFF
--- a/locales.py
+++ b/locales.py
@@ -158,6 +158,14 @@ arising from the use of this program.
                 en="\nCurrent device information:\n",
                 ru="\nТекущая информация об устройстве:\n"
             ),
+            "checking_port": Translation(
+                en="Checking port {port} availability on {ip}...",
+                ru="Проверка доступности порта {port} на {ip}..."
+            ),
+            "port_not_available": Translation(
+                en="Port {port} is not available on {ip}. The device may be off, ADB is not enabled, or the port is incorrect.",
+                ru="Порт {port} недоступен на {ip}. Устройство может быть выключено, ADB не включён или порт указан неверно."
+            ),
             "confirm_connection": Translation(
                 en="Please confirm the connection on the TV screen if prompted.",
                 ru="Пожалуйста, подтвердите подключение на экране ТВ, если появится запрос."
@@ -1069,12 +1077,12 @@ vn: Вьетнам
                 ru="5. Назад в главное меню"
             ),
             "enter_device_ip_scan": Translation(
-                en="Enter device IP or IP:port (press Enter for saved: {saved_ip}, or 's' to scan network): ",
-                ru="Введите IP или IP:порт (Enter для сохранённого: {saved_ip}, или 's' для сканирования): "
+                en="Enter IP or IP:port if port differs from 5555 (press Enter for saved: {saved_ip}, or 's' to scan network): ",
+                ru="Введите IP или IP:порт если порт отличается от 5555 (Enter для сохранённого: {saved_ip}, или 's' для сканирования): "
             ),
             "enter_device_ip_scan_no_saved": Translation(
-                en="Enter device IP or IP:port (or 's' to scan network): ",
-                ru="Введите IP или IP:порт (или 's' для сканирования сети): "
+                en="Enter IP or IP:port if port differs from 5555 (or 's' to scan network): ",
+                ru="Введите IP или IP:порт если порт отличается от 5555 (или 's' для сканирования сети): "
             ),
             "scan_select_device": Translation(
                 en="Select device number (or Enter to cancel): ",

--- a/src/android_time_fixer.py
+++ b/src/android_time_fixer.py
@@ -1359,6 +1359,12 @@ class AndroidTVTimeFixer:
             raise AndroidTVTimeFixerError(locales.get("invalid_ip_format"))
 
         host, port = self.parse_ip_port(ip)
+
+        # Проверяем доступность порта перед попыткой подключения
+        print(Fore.CYAN + locales.get("checking_port", ip=host, port=port))
+        if not self._check_port_available(host, port):
+            raise AndroidTVTimeFixerError(locales.get("port_not_available", ip=host, port=port))
+
         pub, priv = self.load_keys()
         signer = PythonRSASigner(pub, priv)
 
@@ -1437,16 +1443,21 @@ class AndroidTVTimeFixer:
     # Network scan
     # ──────────────────────────────────────────────────────────
 
-    def _check_adb_port(self, ip: str) -> Optional[str]:
-        """Проверяет, открыт ли ADB-порт 5555 на указанном IP"""
+    @staticmethod
+    def _check_port_available(ip: str, port: int, timeout: float = 2.0) -> bool:
+        """Проверяет, открыт ли указанный порт на IP-адресе"""
         try:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            sock.settimeout(0.2)
-            result = sock.connect_ex((ip, 5555))
+            sock.settimeout(timeout)
+            result = sock.connect_ex((ip, port))
             sock.close()
-            return ip if result == 0 else None
+            return result == 0
         except Exception:
-            return None
+            return False
+
+    def _check_adb_port(self, ip: str) -> Optional[str]:
+        """Проверяет, открыт ли ADB-порт 5555 на указанном IP"""
+        return ip if self._check_port_available(ip, 5555, timeout=0.2) else None
 
     @staticmethod
     def _is_private_ip(ip_str: str) -> bool:


### PR DESCRIPTION
- Add _check_port_available() method that checks any port with configurable timeout
- Check port before starting the 120s connection loop to fail fast on wrong ports
- Refactor _check_adb_port() to use the new universal method
- Update prompt text to clarify that port should be specified only if different from 5555
- Add locale strings for port checking/unavailable messages (en/ru)